### PR TITLE
fix: resolve streaming content loss in DraftingView textarea

### DIFF
--- a/src/entrypoints/job-details/views/DraftingView.tsx
+++ b/src/entrypoints/job-details/views/DraftingView.tsx
@@ -105,6 +105,7 @@ export const DraftingView: React.FC<DraftingViewProps> = ({
   const {
     values: documentContents,
     setValue: updateContent,
+    getLatestValue,
     flush,
   } = useAutoSaveMulti({
     initialValues: initialDocumentValues,
@@ -287,8 +288,8 @@ export const DraftingView: React.FC<DraftingViewProps> = ({
             console.info('Thinking update:', delta);
           }}
           onDocumentUpdate={(docKey, delta) => {
-            // Update document content
-            const currentContent = documentContents[docKey] || '';
+            // Use getLatestValue to avoid stale closure during streaming
+            const currentContent = getLatestValue(docKey);
             updateContent(docKey, currentContent + delta);
           }}
           onGenerate={(jobIdx, docKey, result) => {


### PR DESCRIPTION
## Description

Fixes streaming to textarea in DraftingView which was broken due to stale closures and auto-save causing re-renders during streaming.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add `getLatestValue` to `useAutoSaveMulti` hook to read current content from ref instead of stale React state closure
- Add `initialValues` sync effect to `useAutoSaveMulti` to handle external updates (like streaming) while preserving user edits
- Update `DraftingView` to use `getLatestValue` for streaming delta accumulation

## Root Cause

Two issues were causing the streaming bug:

1. **Stale closure**: `onDocumentUpdate` callback captured `documentContents` from when it was created, so each streaming chunk only saw the initial empty string, resulting in only the last word being visible
2. **Auto-save re-renders**: When streaming took >2s, the debounced auto-save would write to storage, triggering a storage change event that updated `initialValues`, but `useAutoSaveMulti` wasn't syncing with external changes (unlike the single-value `useAutoSave` hook)

## Testing

### Manual Testing

- [x] Tested in Chrome

### Test Scenarios

1. Generate a long document - verify all streamed content accumulates and displays
2. Edit a document manually - verify edits are not reset
3. Generate content, then edit - verify both work correctly

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested my changes in at least one browser
- [x] Pre-commit hooks passed (linting and formatting)